### PR TITLE
Add support for Shed Tail

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -183,6 +183,7 @@ SWITCH_OUT_MOVES = {
     "teleport",
     "flipturn",
     "chillyreception",
+    "shedtail",
 }
 
 # volatile statuses

--- a/fp/battle.py
+++ b/fp/battle.py
@@ -189,6 +189,7 @@ class Battler:
         self.name = None
         self.trapped = False
         self.baton_passing = False
+        self.shed_tailing = False
         self.wish = (0, 0)
         self.future_sight = (0, "")
 

--- a/fp/battle_bots/poke_engine_helpers.py
+++ b/fp/battle_bots/poke_engine_helpers.py
@@ -146,6 +146,7 @@ def battler_to_poke_engine_side(
     side = PokeEngineSide(
         active_index="0",
         baton_passing=battler.baton_passing,
+        shed_tailing=battler.shed_tailing,
         pokemon=[pokemon_to_poke_engine_pkmn(battler.active)]
         + [pokemon_to_poke_engine_pkmn(p) for p in battler.reserve],
         side_conditions=PokeEngineSideConditions(

--- a/fp/battle_modifier.py
+++ b/fp/battle_modifier.py
@@ -293,7 +293,7 @@ def switch_or_drag(battle, split_msg, switch_or_drag="switch"):
         side.side_conditions[constants.TOXIC_COUNT] = 0
 
     baton_passed_boosts = None
-    baton_passed_volatiles = []
+    switch_keep_volatiles = []
     if side.active is not None:
         # set the pkmn's types back to their original value if the types were changed
         # if the pkmn is terastallized, this does not happen
@@ -341,10 +341,16 @@ def switch_or_drag(battle, split_msg, switch_or_drag="switch"):
 
             if constants.SUBSTITUTE in side.active.volatile_statuses:
                 logger.info("Baton passing, preserving substitute")
-                baton_passed_volatiles.append(constants.SUBSTITUTE)
+                switch_keep_volatiles.append(constants.SUBSTITUTE)
             if constants.LEECH_SEED in side.active.volatile_statuses:
                 logger.info("Baton passing, preserving leechseed")
-                baton_passed_volatiles.append(constants.LEECH_SEED)
+                switch_keep_volatiles.append(constants.LEECH_SEED)
+        elif split_msg[-1] == "[from] Shed Tail":
+            side.shed_tailing = False
+
+            if constants.SUBSTITUTE in side.active.volatile_statuses:
+                logger.info("Shed tailing, preserving substitute")
+                switch_keep_volatiles.append(constants.SUBSTITUTE)
 
         # gen5 rest turns are reset upon switching
         if battle.generation == "gen5" and side.active.status == constants.SLEEP:
@@ -539,8 +545,8 @@ def switch_or_drag(battle, split_msg, switch_or_drag="switch"):
             )
         )
         side.active.boosts = baton_passed_boosts
-    for volatile in baton_passed_volatiles:
-        logger.info("Baton passing volatile: {}".format(volatile))
+    for volatile in switch_keep_volatiles:
+        logger.info("Keeping volatile on switch: {}".format(volatile))
         side.active.volatile_statuses.append(volatile)
 
 
@@ -958,6 +964,9 @@ def move(battle, split_msg):
 
     if move_name == "batonpass":
         side.baton_passing = True
+
+    if move_name == "shedtail":
+        side.shed_tailing = True
 
     # |move|p1a: Slaking|Earthquake|p2a: Heatran
     if pkmn.ability == "truant" or pkmn.name == "slaking":

--- a/fp/battle_modifier.py
+++ b/fp/battle_modifier.py
@@ -983,9 +983,6 @@ def move(battle, split_msg):
     if move_name == "batonpass":
         side.baton_passing = True
 
-    if move_name == "shedtail":
-        side.shed_tailing = True
-
     # |move|p1a: Slaking|Earthquake|p2a: Heatran
     if pkmn.ability == "truant" or pkmn.name == "slaking":
         if "truant" not in pkmn.volatile_statuses:
@@ -1224,6 +1221,13 @@ def start_volatile_status(battle, split_msg):
         pkmn.volatile_statuses.append(volatile_status)
 
     if volatile_status == constants.SUBSTITUTE:
+        if split_msg[4] == "[from] move: Shed Tail":
+            logger.info(
+                "{} started a substitute from shed tail - setting shed_tailing to True".format(
+                    pkmn.name
+                )
+            )
+            side.shed_tailing = True
         logger.info(
             "{} started a substitute - setting substitute_hit to False".format(
                 pkmn.name

--- a/fp/battle_modifier.py
+++ b/fp/battle_modifier.py
@@ -1221,7 +1221,7 @@ def start_volatile_status(battle, split_msg):
         pkmn.volatile_statuses.append(volatile_status)
 
     if volatile_status == constants.SUBSTITUTE:
-        if split_msg[4] == "[from] move: Shed Tail":
+        if len(split_msg) >= 5 and split_msg[4] == "[from] move: Shed Tail":
             logger.info(
                 "{} started a substitute from shed tail - setting shed_tailing to True".format(
                     pkmn.name

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests==2.32.0
 environs==11.0.0
 websockets==14.1
 python-dateutil==2.8.0
-poke-engine==0.0.40 --config-settings="build-args=--features poke-engine/terastallization --no-default-features"
+poke-engine==0.0.41 --config-settings="build-args=--features poke-engine/terastallization --no-default-features"

--- a/tests/test_battle_modifiers.py
+++ b/tests/test_battle_modifiers.py
@@ -855,22 +855,41 @@ class TestSwitchOrDrag(unittest.TestCase):
     def test_shed_tail_switching_in_gets_shed_tailing_flag_set_to_false(self):
         self.battle.user.shed_tailing = True
 
-        split_msg = ["", "switch", "p1a: Pikachu", "Pikachu, L100, M", "100/100", "[from] Shed Tail"]
+        split_msg = [
+            "",
+            "switch",
+            "p1a: Pikachu",
+            "Pikachu, L100, M",
+            "100/100",
+            "[from] Shed Tail",
+        ]
         switch_or_drag(self.battle, split_msg)
 
         self.assertFalse(self.battle.user.shed_tailing)
 
     def test_shed_tail_switching_in_only_keeps_substitute(self):
-        self.battle.user.active.volatile_statuses = [constants.SUBSTITUTE, constants.LEECH_SEED]
+        self.battle.user.active.volatile_statuses = [
+            constants.SUBSTITUTE,
+            constants.LEECH_SEED,
+        ]
         self.battle.user.active.boosts[constants.SPEED] = 1
         self.battle.user.active.boosts[constants.ATTACK] = -2
 
-        split_msg = ["", "switch", "p1a: Pikachu", "Pikachu, L100, M", "100/100", "[from] Shed Tail"]
+        split_msg = [
+            "",
+            "switch",
+            "p1a: Pikachu",
+            "Pikachu, L100, M",
+            "100/100",
+            "[from] Shed Tail",
+        ]
         switch_or_drag(self.battle, split_msg)
 
         self.assertEqual(0, self.battle.user.active.boosts[constants.SPEED])
         self.assertEqual(0, self.battle.user.active.boosts[constants.ATTACK])
-        self.assertEqual([constants.SUBSTITUTE], self.battle.user.active.volatile_statuses)
+        self.assertEqual(
+            [constants.SUBSTITUTE], self.battle.user.active.volatile_statuses
+        )
 
 
 class TestHealOrDamage(unittest.TestCase):

--- a/tests/test_battle_modifiers.py
+++ b/tests/test_battle_modifiers.py
@@ -852,6 +852,26 @@ class TestSwitchOrDrag(unittest.TestCase):
 
         self.assertEqual(["normal"], ditto.types)
 
+    def test_shed_tail_switching_in_gets_shed_tailing_flag_set_to_false(self):
+        self.battle.user.shed_tailing = True
+
+        split_msg = ["", "switch", "p1a: Pikachu", "Pikachu, L100, M", "100/100", "[from] Shed Tail"]
+        switch_or_drag(self.battle, split_msg)
+
+        self.assertFalse(self.battle.user.shed_tailing)
+
+    def test_shed_tail_switching_in_only_keeps_substitute(self):
+        self.battle.user.active.volatile_statuses = [constants.SUBSTITUTE, constants.LEECH_SEED]
+        self.battle.user.active.boosts[constants.SPEED] = 1
+        self.battle.user.active.boosts[constants.ATTACK] = -2
+
+        split_msg = ["", "switch", "p1a: Pikachu", "Pikachu, L100, M", "100/100", "[from] Shed Tail"]
+        switch_or_drag(self.battle, split_msg)
+
+        self.assertEqual(0, self.battle.user.active.boosts[constants.SPEED])
+        self.assertEqual(0, self.battle.user.active.boosts[constants.ATTACK])
+        self.assertEqual([constants.SUBSTITUTE], self.battle.user.active.volatile_statuses)
+
 
 class TestHealOrDamage(unittest.TestCase):
     def setUp(self):
@@ -2638,6 +2658,24 @@ class TestStartVolatileStatus(unittest.TestCase):
 
         start_volatile_status(self.battle, split_msg)
         self.assertFalse(self.battle.opponent.active.substitute_hit)
+
+    def test_substitute_gets_shed_tailing_flag_set_to_true(self):
+        self.battle.user.active.max_hp = 100
+        self.battle.user.active.hp = 100
+
+        self.battle.opponent.active.hp = 100
+        self.battle.user.active.hp = 100
+
+        messages = [
+            "|move|p1a: Cyclizar|Shed Tail|p1a: Cyclizar",
+            "|-start|p1a: Cyclizar|Substitute|[from] move: Shed Tail",
+            "|-damage|p1a: Cyclizar|50/100",  # damage from sub should not be caught
+        ]
+
+        split_msg = messages[1].split("|")
+
+        start_volatile_status(self.battle, split_msg)
+        self.assertTrue(self.battle.user.shed_tailing)
 
     def test_flashfire_sets_ability_on_opponent(self):
         split_msg = ["", "-start", "p2a: Caterpie", "ability: Flash Fire"]


### PR DESCRIPTION
Introduced `shed_tailing` attribute to manage the state of the Shed Tail move. Consolidated volatile status handling into a single `switch_keep_volatiles` list used for both Baton Pass and Shed Tail scenarios. Updated logging to reflect the changes in volatile status preservation on switching.