### PR TITLE
Added more compatibilities for older generations

### DIFF
--- a/teams/teams/gen9/ou/example
+++ b/teams/teams/gen9/ou/example
@@ -27,7 +27,7 @@ IVs: 0 Atk
 - Foul Play  
 - Grass Knot  
 - Sludge Bomb  
-- Spore  
+- Toxic  
 
 Dragapult @ Choice Band  
 Ability: Infiltrator  


### PR DESCRIPTION
- Fixed bug where opponent's lead was not read in random battles and non team preview battles
- Will now look further back in time to find smogon stats of older / niche metagames
- Made team preview generation agnostic (some old gen metagames like Gen 1 Stadium OU have team preview)
- Can now handle reading in teams which don't specify Pokemon Tera types
- Made the example Gen 9 OU team legal (changed Spore for Toxic)